### PR TITLE
Tweak some rules

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -101,6 +101,7 @@ module.exports = {
         'no-shadow': 2,
         'no-undef-init': 2,
         'no-undefined': 2,
+        'no-undef': 2,
         'no-unused-vars': 2,
         'no-use-before-define': 2,
 

--- a/config/common.js
+++ b/config/common.js
@@ -17,7 +17,7 @@ module.exports = {
         'no-empty': 2,
         'no-ex-assign': 2,
         'no-extra-boolean-cast': 2,
-        'no-extra-parens': 2,
+        'no-extra-parens': [ 2, 'functions' ],
         'no-extra-semi': 2,
         'no-func-assign': 2,
         'no-inner-declarations': 2,

--- a/config/common.js
+++ b/config/common.js
@@ -123,7 +123,10 @@ module.exports = {
         'eol-last': 2,
         'func-call-spacing': [ 2, 'never' ],
         'func-style': [ 1, 'expression' ],
-        'id-length': [ 2, { min: 2 } ],
+        'id-length': [ 2, {
+            min: 2,
+            exceptions: [ 'x', 'y', 'z', 'e', 'i' ]
+        } ],
         indent: [ 2, 4, { SwitchCase: 1 } ],
         'key-spacing': [ 2, {
             beforeColon: false,

--- a/config/react.js
+++ b/config/react.js
@@ -64,7 +64,10 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react#jsx-specific-rules
         'react/jsx-boolean-value': [ 2, 'always' ],
         'react/jsx-closing-bracket-location': 2,
-        'react/jsx-curly-spacing': [ 2, 'always', { spacing: { objectLiterals: 'never' } } ],
+        'react/jsx-curly-spacing': [ 2, 'always', {
+            allowMultiline: true,
+            spacing: { objectLiterals: 'never' }
+        } ],
         'react/jsx-equals-spacing': [ 2, 'never' ],
         'react/jsx-filename-extension': 2,
         'react/jsx-first-prop-new-line': [ 2, 'multiline' ],

--- a/config/react.js
+++ b/config/react.js
@@ -74,7 +74,6 @@ module.exports = {
         'react/jsx-no-bind': 2,
         'react/jsx-no-comment-textnodes': 2,
         'react/jsx-no-duplicate-props': 2,
-        'react/jsx-no-literals': 2,
         'react/jsx-no-undef': 2,
         'react/jsx-pascal-case': 2,
         'react/jsx-sort-props': [ 2, { callbacksLast: true } ],


### PR DESCRIPTION
:wrench: allow functions to return jsx in parens
:wrench: allow multiline props in jsx
:wrench: allow some common one-letter variables
:wrench: disallow undeclared variables
:heavy_minus_sign: don’t require literals in jsx
