### PR TITLE
Bump: eslint@3.15.0

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -102,7 +102,7 @@ module.exports = {
         'no-undef-init': 2,
         'no-undefined': 2,
         'no-undef': 2,
-        'no-unused-vars': 2,
+        'no-unused-vars': [ 2, { ignoreRestSiblings: true } ],
         'no-use-before-define': 2,
 
         // Stylistic Issues
@@ -204,6 +204,7 @@ module.exports = {
         'space-infix-ops': 2,
         'space-unary-ops': [ 2, { words: true, nonwords: false } ],
         'spaced-comment': [ 2, 'always' ],
+        'template-tag-spacing': [ 2, 'never' ],
         'unicode-bom': [ 2, 'never' ],
 
         // https://github.com/jfmengels/eslint-plugin-fp

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "config/"
   ],
   "peerDependencies": {
-    "eslint": "~3.14.0"
+    "eslint": "~3.15.0"
   },
   "dependencies": {
     "babel-eslint": "~7.1.1",


### PR DESCRIPTION
Having `ignoreRestSiblings` set to `true` might be a nice way to omit props in react components.